### PR TITLE
[DO NOT MERGE] replace date.fromisoformat with dateutil.isoparse

### DIFF
--- a/zgw_consumers/api_models/base.py
+++ b/zgw_consumers/api_models/base.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from functools import partial
 from typing import Any, Dict, List, Union
 
-from dateutil.parser import parse
+from dateutil.parser import isoparse, parse
 from dateutil.relativedelta import relativedelta
 from relativedeltafield import parse_relativedelta
 
@@ -30,7 +30,7 @@ CONVERTERS = {
     dict: noop,  # TODO: recurse?
     uuid.UUID: lambda value: uuid.UUID(value),
     datetime: parse,
-    date: date.fromisoformat,
+    date: isoparse,
     relativedelta: parse_relativedelta,
     bool: noop,
 }

--- a/zgw_consumers/api_models/catalogi.py
+++ b/zgw_consumers/api_models/catalogi.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import List, Optional, Union
 
-from dateutil.parser import parse
+from dateutil.parser import isoparse, parse
 from dateutil.relativedelta import relativedelta
 
 from .base import Model, ZGWModel, factory
@@ -110,7 +110,7 @@ class EigenschapSpecificatie(Model):
 EIGENSCHAP_FORMATEN = {
     "tekst": str,
     "getal": lambda val: Decimal(val.replace(",", ".")),
-    "datum": date.fromisoformat,
+    "datum": isoparse,
     "datum_type": parse,
 }
 


### PR DESCRIPTION
Required to support python 3.6