### PR TITLE
Issue/get paginated results

### DIFF
--- a/tests/schemas/books.yaml
+++ b/tests/schemas/books.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+name: books
+paths:
+  /books:
+    get:
+      operationId: book_list
+      parameters:
+      - name: name
+        in: query
+        required: false
+        schema:
+          type: string

--- a/tests/test_get_paginated_results.py
+++ b/tests/test_get_paginated_results.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+
+from zgw_consumers.constants import APITypes
+from zgw_consumers.models import Service
+from zgw_consumers.service import get_paginated_results
+from zgw_consumers.test import mock_service_oas_get
+
+pytestmark = pytest.mark.django_db
+
+TESTS_DIR = Path(__file__).parent
+BOOK_API_ROOT = "https://book.example.org/api/v1/"
+
+
+def test_paginated_results(settings, requests_mock):
+    """
+    check that function works and doesn't fall into infinite loop
+    """
+    settings.ZGW_CONSUMERS_TEST_SCHEMA_DIRS = [TESTS_DIR / "schemas"]
+    mock_service_oas_get(requests_mock, BOOK_API_ROOT, "books")
+    requests_mock.get(
+        f"{BOOK_API_ROOT}books",
+        complete_qs=True,
+        json={
+            "count": 2,
+            "next": f"{BOOK_API_ROOT}books?page=2",
+            "previous": None,
+            "results": [{"name": "A"}],
+        },
+    )
+    requests_mock.get(
+        f"{BOOK_API_ROOT}books?page=2",
+        complete_qs=True,
+        json={
+            "count": 2,
+            "next": None,
+            "previous": f"{BOOK_API_ROOT}books?page=1",
+            "results": [{"name": "B"}],
+        },
+    )
+
+    service = Service.objects.create(
+        api_type=APITypes.orc,
+        api_root=BOOK_API_ROOT,
+        oas=f"{BOOK_API_ROOT}schema/openapi.yaml?v=3",
+    )
+    client = service.build_client()
+
+    result = get_paginated_results(client, "book")
+
+    assert result == [{"name": "A"}, {"name": "B"}]

--- a/zgw_consumers/client.py
+++ b/zgw_consumers/client.py
@@ -31,14 +31,26 @@ def load_schema_file(file: IO):
     return spec
 
 
-@dataclass
 class ZGWClient(Client):
-    auth_value: Optional[Dict[str, str]] = None
-    schema_url: str = ""
-    schema_file: IO = None
-    client_certificate_path = None
-    client_private_key_path = None
-    server_certificate_path = None
+    def __init__(
+        self,
+        *args,
+        auth_value: Optional[Dict[str, str]] = None,
+        schema_url: str = "",
+        schema_file: IO = None,
+        client_certificate_path=None,
+        client_private_key_path=None,
+        server_certificate_path=None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        self.auth_value = auth_value
+        self.schema_url = schema_url
+        self.schema_file = schema_file
+        self.client_certificate_path = client_certificate_path
+        self.client_private_key_path = client_private_key_path
+        self.server_certificate_path = server_certificate_path
 
     def fetch_schema(self) -> None:
         """support custom OAS resolution"""

--- a/zgw_consumers/service.py
+++ b/zgw_consumers/service.py
@@ -17,7 +17,8 @@ def get_paginated_results(
     *args,
     **kwargs
 ) -> list:
-    query_params = kwargs.get("query_params", {})
+    request_kwargs = kwargs.get("request_kwargs", {})
+    request_params = request_kwargs.get("params", {})
 
     results = []
     response = client.list(resource, *args, **kwargs)
@@ -37,8 +38,11 @@ def get_paginated_results(
         next_url = urlparse(response["next"])
         query = parse_qs(next_url.query)
         new_page = int(query["page"][0])
-        query_params["page"] = [new_page]
-        kwargs["query_params"] = query_params
+
+        request_params["page"] = [new_page]
+        request_kwargs["params"] = request_params
+        kwargs["request_kwargs"] = request_kwargs
+
         response = client.list(resource, *args, **kwargs)
         results += _get_results(response)
 


### PR DESCRIPTION
1. This PR fixes bug in `get_paginated_results` function, which was discovered in Open Inwoner. Now inside the loop in this function the `page` parameter is added to `query_params` variable which is not visible by the `Client.request` method
2. ZGWClient can't see `__init__` of its parent class. which leads to errors, so I removed `@dataclass` decorator
