### PR TITLE
:heavy_minus_sign: Drop unused dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     gemma-zds-client>=2.0.0
     django-simple-certmanager>=1.4.1
     requests
-    pyopenssl
     ape-pie
 tests_require =
     django-redis


### PR DESCRIPTION
Left-over from before the certificates were split off into their own library.