### PR TITLE
:fire: remove django 3.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11']
-        django: ['3.2', '4.2']
-        exclude:
-          - python: '3.11'
-            django: '3.2'
+        django: ['4.2']
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }}
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 * Python 3.10 or newer
-* Django 3.2 or newer
+* Django 4.2 or newer
 
 
 Install

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,7 +7,7 @@ Installation
 **Requirements**
 
 * Python 3.10 or newer
-* Django 3.2+
+* Django 4.2+
 
 1. Install from PyPI using ``pip``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ keywords = ["Django", "ZGW", "Common Ground", "VNG", "API", "OpenAPI", "OAS", "m
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Intended Audience :: Developers",
     "Operating System :: Unix",
@@ -27,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "django>=3.2",
+    "django>=4.2",
     "django-relativedelta>=2.0.0",
     "django-solo",
     "django-simple-certmanager>=1.4.1",

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -10,10 +10,6 @@ def test_oas_fields_enabled(admin_client: Client, settings):
 
     form = response.context["adminform"]
 
-    # django 3.2
-    if hasattr(form, "form"):
-        form = form.form
-
     assert "oas" in form.fields
     assert "oas_file" in form.fields
 
@@ -25,10 +21,6 @@ def test_oas_fields_disabled(admin_client: Client, settings):
     response = admin_client.get(url)
 
     form = response.context["adminform"]
-
-    # django 3.2
-    if hasattr(form, "form"):
-        form = form.form
 
     assert "oas" not in form.fields
     assert "oas_file" not in form.fields

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py310-django{32,42}
-    py311-django42
+    py{310,311}-django42
     isort
     black
     flake8
@@ -15,7 +14,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
     4.2: django42
 
 [testenv]
@@ -35,7 +33,6 @@ extras =
     tests
     coverage
 deps =
-  django32: Django~=3.2.0
   django42: Django~=4.2.0
 commands =
   pytest -s tests \


### PR DESCRIPTION
Remove the mention of Django 3.2 in documentation
Remove Django 3.2 tests in github workflows and tox