### PR TITLE
:bug: Fix slug field migration with appropriate max_length

### DIFF
--- a/zgw_consumers/migrations/0022_set_default_service_slug.py
+++ b/zgw_consumers/migrations/0022_set_default_service_slug.py
@@ -16,6 +16,9 @@ def set_service_slug_default_from_api_root(apps, schema_editor):
 
     for row in Service.objects.all():
         candidate_slug = slugify(row.label if row.label else row.api_root)
+        if len(candidate_slug) > 254:
+            candidate_slug = candidate_slug[:250]
+
         row.slug = generate_unique_slug(candidate_slug)
         row.save(update_fields=["slug"])
 
@@ -34,6 +37,7 @@ class Migration(migrations.Migration):
                 unique=False,
                 blank=True,
                 db_index=False,
+                max_length=255,
             ),
             preserve_default=False,
         ),

--- a/zgw_consumers/models/services.py
+++ b/zgw_consumers/models/services.py
@@ -44,6 +44,7 @@ class Service(RestAPIService):
         help_text=_(
             "A unique, human-friendly slug to identify this service. Primarily useful for cross-instance import/export."
         ),
+        max_length=255,
     )
     api_type = models.CharField(_("type"), max_length=20, choices=APITypes.choices)
     api_root = models.CharField(_("api root url"), max_length=255, unique=True)


### PR DESCRIPTION
Previously, the migration that introduced the slug field to the Service model used the default max_length of 50, which conflicted with our data migration which set the field by slugifying the api_root (which has a max_length of 255).

This commit addresses this by increasing the slug field size, and also by checking for the limit in the migration. We had to yank the 0.35.0 release because this migration would have failed on a large proportion of deploys, so this will be released as part of 0.35.1.