### PR TITLE
Release 0.35.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,21 @@
 Changes
 =======
 
-0.35.0 (2024-07-31)
+0.35.1 (2024-08-15)
 -------------------
+
+Bugfix release.
+
+* 🐛 The data migration introduced in 0.35.0 would initialize the ``slug`` 
+  field in such a way that the generated slug would typically exceed the 
+  field's ``max_length``. This release fixes the field and the underlying
+  migration.
+
+0.35.0💥 (2024-08-13)
+-------------------
+
+**💥 0.35.0 has been yanked and should not be used to avoid ending up in
+an inconsistent migration state. Use 0.35.1 instead.**
 
 Small feature release.
 
@@ -10,7 +23,13 @@ Small feature release.
   instances. As this field is required, the included migration will initiaize
   this field with a slugified version of the ``api_root`` field.
 * ✨ Added natural key getters to the ``Service`` model to support Django's 
-   natural key-based (de)serialization methods.
+  natural key-based (de)serialization methods.
+
+**💥 Breaking changes**
+
+* Because ``slug`` is now a required field, you may have to update your
+  custom ``Service`` creation or testing logic to ensure the field is
+  properly set.
 
 0.34.0 (2024-07-31)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Welcome to ZGW Consumers' documentation!
 ========================================
 
-:Version: 0.35.0
+:Version: 0.35.1
 :Source: https://github.com/maykinmedia/zgw-consumers
 :Keywords: OpenAPI, Zaakgericht Werken, Common Ground, NLX
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zgw-consumers"
-version = "0.35.0"
+version = "0.35.1"
 description = "Configuration for service (OpenAPI 3 or other) consumers"
 authors = [
     {name = "Maykin Media", email = "support@maykinmedia.nl"}
@@ -101,7 +101,7 @@ testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "testapp.settings"
 
 [tool.bumpversion]
-current_version = "0.35.0"
+current_version = "0.35.1"
 files = [
     {filename = "pyproject.toml"},
     {filename = "README.rst"},


### PR DESCRIPTION
Note that this release is a second iteration, following a regrettable force-push to fix a broken migration in the first iteration.