### PR TITLE
:bookmark: Release version 0.38.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+0.38.1 (2025-06-16)
+-------------------
+
+* [#112] Add ``jwt_valid_for`` to the django-setup-configuration model
+
 0.38.0 (2025-04-01)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Welcome to ZGW Consumers' documentation!
 ========================================
 
-:Version: 0.38.0
+:Version: 0.38.1
 :Source: https://github.com/maykinmedia/zgw-consumers
 :Keywords: OpenAPI, Zaakgericht Werken, Common Ground, NLX
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = "2022, Maykin Media"
 author = "Maykin Media"
 
 # The full version, including alpha/beta/rc tags
-release = "0.38.0"
+release = "0.38.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zgw-consumers"
-version = "0.38.0"
+version = "0.38.1"
 description = "Configuration for service (OpenAPI 3 or other) consumers"
 authors = [
     {name = "Maykin Media", email = "support@maykinmedia.nl"}
@@ -107,7 +107,7 @@ markers = [
 ]
 
 [tool.bumpversion]
-current_version = "0.38.0"
+current_version = "0.38.1"
 files = [
     {filename = "pyproject.toml"},
     {filename = "README.rst"},

--- a/zgw_consumers/locale/nl/LC_MESSAGES/django.po
+++ b/zgw_consumers/locale/nl/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 0.38.0\n"
+"Project-Id-Version: 0.38.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-01 08:04-0500\n"
 "PO-Revision-Date: 2022-05-17 09:40+02:00\n"


### PR DESCRIPTION
Note to self: tag the last commit of the `release/0.38.1` branch, not the merge commit after merging, because #108 was merged)