### PR TITLE
[#124] Fix crash in connection check

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -73,3 +73,24 @@ def test_get_connection_opening_add_page(admin_client: Client, settings):
         '<label>Connection check status code:</label><div class="readonly">n/a</div>'
     )
     assertContains(response, connection_check_inner_html, html=True)
+
+
+def test_custom_exception_in_connection_check_is_handled(admin_client: Client):
+    service = ServiceFactory.create(
+        api_root="https://example.com/",
+        api_connection_check_path="foo",
+        auth_type=AuthTypes.zgw,
+        client_id="my-client-id",
+        secret="my-secret",
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get("https://example.com/foo", exc=Exception)
+
+        url = reverse(
+            "admin:zgw_consumers_service_change", kwargs={"object_id": service.id}
+        )
+        response = admin_client.get(url)
+
+        connection_check_inner_html = '<label>Connection check status code:</label><div class="readonly">None</div>'
+        assertContains(response, connection_check_inner_html, html=True)

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ extras =
     oauth2
 deps =
   django42: Django~=4.2.0
+  django52: Django~=5.2.0
 commands =
   pytest -s tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \

--- a/zgw_consumers/admin.py
+++ b/zgw_consumers/admin.py
@@ -1,6 +1,4 @@
 from django.contrib import admin
-from django.db import models
-from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from privates.admin import PrivateMediaMixin
@@ -8,7 +6,6 @@ from solo.admin import SingletonModelAdmin
 
 from .admin_fields import get_nlx_field
 from .models.services import NLXConfig, Service
-from .settings import get_setting
 from .widgets import NoDownloadPrivateFileWidget
 
 

--- a/zgw_consumers/models/services.py
+++ b/zgw_consumers/models/services.py
@@ -12,7 +12,6 @@ from django.db.models.functions import Length
 from django.utils.translation import gettext_lazy as _
 
 from privates.fields import PrivateMediaFileField
-from requests.exceptions import RequestException
 from simple_certmanager.models import Certificate
 from solo.models import SingletonModel
 from typing_extensions import Self
@@ -264,7 +263,10 @@ class Service(_Service):
             return client.get(
                 self.api_connection_check_path or self.api_root
             ).status_code
-        except RequestException as e:
+        # Catching generic exceptions is not ideal but we cannot handle this kind of
+        # situations in another way. This helps and informs the user about the problem
+        # of the service configuration instead of crashing the application (change page).
+        except Exception as e:
             logger.info(
                 "Encountered an error while performing the connection check to service %s",
                 self,


### PR DESCRIPTION
Closes #124

The problem occurs when a user wants to access a saved instance (Service). When this is happening a connection check is being made (`connection_check`) which crashes the application if a random exception is raised (we only catch a specific one now).

The solution is to catch the generic `Exception`, even if it's not ideal, in order to let the admin user configure properly the settings for the service. This is not added to the clean method of the model on purpose (we already treat that in this way), not needed imo. Let me know if you agree with this.