### PR TITLE
fix pagination annotations

### DIFF
--- a/tests/test_pagination_helper.py
+++ b/tests/test_pagination_helper.py
@@ -1,9 +1,13 @@
+import sys
+from typing import Literal
+
 import pytest
 
 from zgw_consumers.client import build_client
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 from zgw_consumers.service import pagination_helper
+from zgw_consumers.utils import PaginatedResponseData
 
 pytestmark = pytest.mark.django_db
 
@@ -128,3 +132,35 @@ def test_paginated_results_max_requests(settings, requests_mock):
     all_data = pagination_helper(client, data, max_requests=1)
 
     assert list(all_data) == [{"name": "A"}, {"name": "B"}]
+
+
+@pytest.mark.xfail
+def test_paginated_results_max_requests_bigger_than_recursionlimit(
+    settings, requests_mock
+):
+    requests_mock.get(
+        f"{BOOK_API_ROOT}books",
+        json={
+            "count": 1_000_000,  # Dr. Evil
+            "next": f"{BOOK_API_ROOT}books",  # inifinite loop
+            "previous": None,
+            "results": [1],
+        },
+    )
+
+    service = Service.objects.create(
+        api_type=APITypes.orc,
+        api_root=BOOK_API_ROOT,
+        auth_type=AuthTypes.no_auth,
+    )
+    client = build_client(service)
+
+    response = client.get("books")
+    response.raise_for_status()
+    data = response.json()
+
+    limit = sys.getrecursionlimit()
+    all_data = pagination_helper(client, data, max_requests=limit)
+
+    # limit from the requests + 1 from the initial data
+    assert sum(all_data) == limit + 1  # type: ignore  # of the mock we *know* it returns Literal[1]

--- a/zgw_consumers/utils.py
+++ b/zgw_consumers/utils.py
@@ -1,6 +1,6 @@
 import logging
-from collections.abc import Callable
-from typing import TypedDict
+from collections.abc import Callable, Iterable
+from typing import NotRequired, TypedDict
 
 from django.http import HttpRequest
 
@@ -33,26 +33,26 @@ class cache_on_request:
         return cached_value
 
 
-class PaginatedResponseData(TypedDict):
+class PaginatedResponseData[T](TypedDict):
     count: int
-    next: str
-    previous: str
-    results: list
+    next: NotRequired[str | None]
+    previous: NotRequired[str | None]
+    results: Iterable[T]
 
 
-def pagination_helper(
+def pagination_helper[T](
     client: APIClient,
-    paginated_data: PaginatedResponseData,
+    paginated_data: PaginatedResponseData[T],
     max_requests: int | None = None,
     **kwargs,
-):
+) -> Iterable[T | object]:
     """
     Fetch results from a paginated API endpoint, and optionally limit the number of
     requests to perform when fetching new pages by specifying the ``max_requests``
-    argument
+    argument.
     """
 
-    def _iter(_data, num_requests=0):
+    def _iter(_data: PaginatedResponseData[T], num_requests=0):
         yield from _data["results"]
         if next_url := _data.get("next"):
             if max_requests and num_requests >= max_requests:


### PR DESCRIPTION
- **:label: fix: Make pagination_helper annotations reflect Open Zaak API**
- **:test_tube: test: max_requests not always reached... Feature or Bug?**

Asking if it's a feature or a bug, because I saw the helper being used in a search indexing task...